### PR TITLE
fix: make the cassandra package runnable

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,1 @@
-name: github.com/kurtosis-tech/cassandra-package
+name: "github.com/kurtosis-tech/cassandra-package"


### PR DESCRIPTION
Before: the cassandra-package was _not_ runnable because the kurtosis.yml file did not have double quotes around the name of the locator

After: added double quotes to make this package runnable