### PR TITLE
fix: reduce max_heap_size from 1024m to 500m

### DIFF
--- a/main.star
+++ b/main.star
@@ -54,7 +54,7 @@ def get_service_config(num_nodes):
         env_vars = {
             "CASSANDRA_SEEDS":",".join(seeds),
             # without this set Cassandra tries to take 8G and OOMs
-            "MAX_HEAP_SIZE": "1024M",
+            "MAX_HEAP_SIZE": "500M",
             "HEAP_NEWSIZE": "1M",
         }
     )


### PR DESCRIPTION
@h4ck3rk3y: for our parameterizability example, i wrote our guide to spin up n=5 nodes. This probably hogs up way too much memory on a local machine so I reduced the max heap size to 500m to make it easier to run 5 cass nodes.