### PR TITLE
refactor: disabled automatic port wait for some ports

### DIFF
--- a/main.star
+++ b/main.star
@@ -9,10 +9,12 @@ CASSANDRA_NODE_IMAGE = "cassandra:4.0"
 CLUSTER_COMM_PORT_ID = "cluster"
 CLUSTER_COM_PORT_NUMBER =  7000
 CLUSTER_COM_PORT_PROTOCOL = "TCP"
+CLUSTER_COM_PORT_AUTOMATIC_WAIT_DISABLE = None
 
 CLIENT_COMM_PORT_ID = "client"
 CLIENT_COM_PORT_NUMBER = 9042
 CLIENT_COM_PORT_PROTOCOL = "TCP"
+CLIENT_COM_PORT_AUTOMATIC_WAIT_DISABLE = None
 
 FIRST_NODE_INDEX = 0
 
@@ -83,8 +85,8 @@ def get_service_config(num_nodes):
     return ServiceConfig(
         image = CASSANDRA_NODE_IMAGE,
         ports = {
-            CLUSTER_COMM_PORT_ID : PortSpec(number = CLUSTER_COM_PORT_NUMBER, transport_protocol = CLUSTER_COM_PORT_PROTOCOL),
-            CLIENT_COMM_PORT_ID : PortSpec(number = CLIENT_COM_PORT_NUMBER, transport_protocol = CLIENT_COM_PORT_PROTOCOL),
+            CLUSTER_COMM_PORT_ID : PortSpec(number = CLUSTER_COM_PORT_NUMBER, transport_protocol = CLUSTER_COM_PORT_PROTOCOL, wait = CLUSTER_COM_PORT_AUTOMATIC_WAIT_DISABLE),
+            CLIENT_COMM_PORT_ID : PortSpec(number = CLIENT_COM_PORT_NUMBER, transport_protocol = CLIENT_COM_PORT_PROTOCOL, wait = CLIENT_COM_PORT_AUTOMATIC_WAIT_DISABLE),
         },
         env_vars = {
             "CASSANDRA_SEEDS":",".join(seeds),
@@ -100,8 +102,8 @@ def get_service_config_with_monitoring(num_nodes):
     return ServiceConfig(
         image = CASSANDRA_NODE_IMAGE,
         ports = {
-            CLUSTER_COMM_PORT_ID : PortSpec(number = CLUSTER_COM_PORT_NUMBER, transport_protocol = CLUSTER_COM_PORT_PROTOCOL),
-            CLIENT_COMM_PORT_ID : PortSpec(number = CLIENT_COM_PORT_NUMBER, transport_protocol = CLIENT_COM_PORT_PROTOCOL),
+            CLUSTER_COMM_PORT_ID : PortSpec(number = CLUSTER_COM_PORT_NUMBER, transport_protocol = CLUSTER_COM_PORT_PROTOCOL, wait = CLUSTER_COM_PORT_AUTOMATIC_WAIT_DISABLE),
+            CLIENT_COMM_PORT_ID : PortSpec(number = CLIENT_COM_PORT_NUMBER, transport_protocol = CLIENT_COM_PORT_PROTOCOL, wait = CLIENT_COM_PORT_AUTOMATIC_WAIT_DISABLE),
             METRICS_PORT_ID: PortSpec(number = METRICS_PORT_NUMBER, transport_protocol = METRICS_PORT_PROTOCOL)
         },
         env_vars = {

--- a/main.star
+++ b/main.star
@@ -66,7 +66,7 @@ def run(plan, args):
         command = ["/bin/sh", "-c", node_tool_check],
     )
 
-    plan.wait(recipe = check_nodes_are_up, field = "output", assertion = "==", target_value = str(num_nodes), timeout = "8m", service_name = get_first_node_name())
+    plan.wait(recipe = check_nodes_are_up, field = "output", assertion = "==", target_value = str(num_nodes), timeout = "10m", service_name = get_first_node_name())
 
     result =  {"node_names": [node.name for node in started_nodes]}
 


### PR DESCRIPTION
In this PR https://github.com/kurtosis-tech/kurtosis/pull/534 we are going to release the automatic ports wait feature which checks all the service's ports with a default 15 seconds timeout, this value is not enough for some ports in this package, so this PR is for increasing the wait timeout just for this service.