### PR TITLE
fix: broken launch when monitoring is enabled

### DIFF
--- a/monitoring/grafana.star
+++ b/monitoring/grafana.star
@@ -1,15 +1,15 @@
 GRAFANA_IMAGE = "grafana/grafana-enterprise:9.2.3"
 
 GRAFANA_CONFIG_DIR = "/config"
-GRAFANA_DATASOURCE_CONFIG_TEMPLATE_PATH =  "./static_files/grafana-datasoure.yml.tmpl"
+GRAFANA_DATASOURCE_CONFIG_TEMPLATE_PATH =  "/static_files/grafana-datasoure.yml.tmpl"
 GRAFANA_DATASOURCE_CONFIG_TEMPLATE_FILENAME = "datasources/datasource.yml"
-GRAFANA_DASHBOARD_PROVIDER_CONFIG_TEMPLATE_PATH = "./static_files/grafana-dashboards-providers.yml.tmpl"
+GRAFANA_DASHBOARD_PROVIDER_CONFIG_TEMPLATE_PATH = "/static_files/grafana-dashboards-providers.yml.tmpl"
 GRAFNA_DASHBOARD_PROVIDER_CONFIG_YML_FILENAME = "dashboards/dashboard-providers.yml"
 
 GRAFANA_DASHBOARDS_DIR = "/dashboards"
 GRAFANA_DASHBOARDS_FILENAME = "grafana-dashboards.json"
 GRAFANA_DASHBOARDS_FILEPATH = GRAFANA_DASHBOARDS_DIR  + "/" + GRAFANA_DASHBOARDS_FILENAME
-GRAFANA_DASHBOARDS_FILEPATH_IN_PACKAGE = "./static_files/grafana-dashboards.json"
+GRAFANA_DASHBOARDS_FILEPATH_IN_PACKAGE = "/static_files/grafana-dashboards.json"
 
 GRAFANA_HTTP_PORT_ID = "http"
 GRAFANA_HTTP_PORT_NUMBER = 3000

--- a/monitoring/prometheus.star
+++ b/monitoring/prometheus.star
@@ -1,6 +1,6 @@
 PROMETHEUS_IMAGE = "prom/prometheus:latest"
 
-PROMETHEUS_CONFIG_TEMPLATE_PATH = "./static_files/prometheus.yml.tmpl"
+PROMETHEUS_CONFIG_TEMPLATE_PATH = "/static_files/prometheus.yml.tmpl"
 PROMETHEUS_CONFIG_DIR = "/config"
 PROMETHEUS_YML_TARGET_FILE_NAME = "prometheus.yml"
 PROMETHEUS_YML_TARGET_PATH = PROMETHEUS_CONFIG_DIR + "/" + PROMETHEUS_YML_TARGET_FILE_NAME


### PR DESCRIPTION
I tried to launch cassandra with monitoring, which gave this error:

```
√ kurtosis-postgres % kurtosis run github.com/kurtosis-tech/cassandra-package '{"monitoring_enabled": true}'
INFO[2023-10-17T09:44:49+01:00] Creating a new enclave for Starlark to run inside...
INFO[2023-10-17T09:44:58+01:00] Enclave 'smooth-cliff' created successfully
There was an error interpreting Starlark code
Evaluation error: '/monitoring/static_files/prometheus.yml.tmpl' doesn't exist in the package 'kurtosis-tech/cassandra-package'
	at [github.com/kurtosis-tech/cassandra-package/main.star:62:68]: run
	at [github.com/kurtosis-tech/cassandra-package/monitoring/prometheus.star:14:36]: start_prometheus
	at [0:0]: read_file

Error encountered running Starlark code.
INFO[2023-10-17T09:44:59+01:00] =====================================================
INFO[2023-10-17T09:44:59+01:00] ||          Created enclave: smooth-cliff          ||
INFO[2023-10-17T09:44:59+01:00] =====================================================
Name:            smooth-cliff
UUID:            b4b6e5c26f4a
Status:          RUNNING
Creation Time:   Tue, 17 Oct 2023 09:44:49 BST

========================================= Files Artifacts =========================================
UUID   Name

========================================== User Services ==========================================
UUID   Name   Ports   Status
```

I've made the relevant paths absolute, which gives me an ok launch and a working dashboard.   Not 100% sure I've fixed this correctly, so please be suspicious.